### PR TITLE
Update 06_1_Gateway_Policies_Lab.adoc

### DIFF
--- a/modules/06_Gateway_Policies/06_1_Gateway_Policies_Lab.adoc
+++ b/modules/06_Gateway_Policies/06_1_Gateway_Policies_Lab.adoc
@@ -4,6 +4,8 @@
 :linkattrs:
 :data-uri:
 
+
+
 == API Gateway Policies Lab
 
 In this lab you learn about API gateway policies.


### PR DESCRIPTION
Verified the lab using my own API. APICast policies instructions are fine.
But, this lab refers to products api which fails to deploy. Either fix the products API or replace it with another API and change references to it in the lab